### PR TITLE
Retry to use http when OpenSSL::SSL::SSLError raises

### DIFF
--- a/lib/goldfinger/client.rb
+++ b/lib/goldfinger/client.rb
@@ -39,7 +39,7 @@ module Goldfinger
 
       begin
         template = perform_get(url(ssl))
-      rescue HTTP::Error
+      rescue HTTP::Error, OpenSSL::SSL::SSLError
         raise Goldfinger::NotFoundError unless ssl
 
         ssl = false

--- a/lib/goldfinger/client.rb
+++ b/lib/goldfinger/client.rb
@@ -18,9 +18,12 @@ module Goldfinger
         return finger_from_template if response.code != 200
 
         Goldfinger::Result.new(response)
-      rescue HTTP::Error, OpenSSL::SSL::SSLError
-        raise Goldfinger::NotFoundError unless ssl
-
+      rescue HTTP::Error
+        raise Goldfinger::NotFoundError unless ssl and ENV['LOCAL_HTTPS'] != 'true'
+        ssl = false
+        retry
+      rescue OpenSSL::SSL::SSLError
+        raise Goldfinger::SSLError unless ssl and ENV['LOCAL_HTTPS'] != 'true'
         ssl = false
         retry
       end
@@ -39,9 +42,12 @@ module Goldfinger
 
       begin
         template = perform_get(url(ssl))
-      rescue HTTP::Error, OpenSSL::SSL::SSLError
-        raise Goldfinger::NotFoundError unless ssl
-
+      rescue HTTP::Error
+        raise Goldfinger::NotFoundError unless ssl and ENV['LOCAL_HTTPS'] != 'true'
+        ssl = false
+        retry
+      rescue OpenSSL::SSL::SSLError
+        raise Goldfinger::SSLError unless ssl and ENV['LOCAL_HTTPS'] != 'true'
         ssl = false
         retry
       end

--- a/lib/goldfinger/client.rb
+++ b/lib/goldfinger/client.rb
@@ -18,7 +18,7 @@ module Goldfinger
         return finger_from_template if response.code != 200
 
         Goldfinger::Result.new(response)
-      rescue HTTP::Error
+      rescue HTTP::Error, OpenSSL::SSL::SSLError
         raise Goldfinger::NotFoundError unless ssl
 
         ssl = false


### PR DESCRIPTION
We are using http for mastodon instance inside of the company,
but when the instance opens port 443 or uses different port from 80,
goldfinger library fail to fetch the webfinger because of SSLError.
Could you retry to use http when the OpenSSL::SSL::SSLError raises?