### PR TITLE
Cast HTTP response body for JSON to string (regression from #4)

### DIFF
--- a/lib/goldfinger/result.rb
+++ b/lib/goldfinger/result.rb
@@ -74,7 +74,7 @@ module Goldfinger
     end
 
     def parse_json
-      json = Oj.load(@body, mode: :null)
+      json = Oj.load(@body.to_s, mode: :null)
 
       @subject    = json['subject']
       @aliases    = json['aliases'] || []


### PR DESCRIPTION
[Oj](https://github.com/ohler55/oj) uses `readpartial` instead of `to_s` if the value given for the arguments has a `readpartial` method ([`ext/oj/reader.c#L73-L75`](https://github.com/ohler55/oj/blob/v3.3.4/ext/oj/reader.c#L73-L75)). Also, [HTTP.rb](https://github.com/httprb/http) splits the response if `Transfer-Encoding: chunked` is returned in the HTTP headers ([`lib/http/response/body.rb#L26-L30`](https://github.com/httprb/http/blob/v2.2.2/lib/http/response/body.rb#L26-L30)).

Will use `to_s` like `JSON.parse` which was used previously ([`ext/json/ext/parser/parser.c#L1824`](https://github.com/flori/json/blob/v2.1.0/ext/json/ext/parser/parser.c#L1824)).

### error case

![Sidekiq screenshot](https://user-images.githubusercontent.com/12539/28962231-f60f5bca-793f-11e7-8d67-62a40d75575f.png)
