### PR TITLE
Enable to pass options to HTTP.rb, Allow insecure request

### DIFF
--- a/lib/goldfinger.rb
+++ b/lib/goldfinger.rb
@@ -18,8 +18,10 @@ module Goldfinger
   # @raise [Goldfinger::NotFoundError] Error raised when the Webfinger resource could not be retrieved
   # @raise [Goldfinger::SSLError] Error raised when there was a SSL error when fetching the resource
   # @param uri [String] A full resource identifier in the format acct:user@example.com
+  # @param opts [Hash] Options passed to HTTP.rb client
+  # @param ssl [Boolean] Whether performs secure HTTP reqest. MUST NOT set to false in the usual case
   # @return [Goldfinger::Result]
-  def self.finger(uri)
-    Goldfinger::Client.new(uri).finger
+  def self.finger(uri, opts = {}, ssl = true)
+    Goldfinger::Client.new(uri, opts, ssl).finger
   end
 end

--- a/lib/goldfinger.rb
+++ b/lib/goldfinger.rb
@@ -19,9 +19,8 @@ module Goldfinger
   # @raise [Goldfinger::SSLError] Error raised when there was a SSL error when fetching the resource
   # @param uri [String] A full resource identifier in the format acct:user@example.com
   # @param opts [Hash] Options passed to HTTP.rb client
-  # @param ssl [Boolean] Whether performs secure HTTP reqest. MUST NOT set to false in the usual case
   # @return [Goldfinger::Result]
-  def self.finger(uri, opts = {}, ssl = true)
-    Goldfinger::Client.new(uri, opts, ssl).finger
+  def self.finger(uri, opts = {})
+    Goldfinger::Client.new(uri, opts).finger
   end
 end

--- a/lib/goldfinger/client.rb
+++ b/lib/goldfinger/client.rb
@@ -9,8 +9,9 @@ module Goldfinger
 
     def initialize(uri, opts = {})
       @uri = uri
-      @scheme = opts.fetch(:ssl, true) ? "https" : "http"
-      @opts = opts.delete(:ssl) || opts
+      @ssl = opts.delete(:ssl) { true }
+      @scheme = @ssl ? 'https' : 'http'
+      @opts = opts
     end
 
     def finger

--- a/lib/goldfinger/client.rb
+++ b/lib/goldfinger/client.rb
@@ -7,10 +7,10 @@ module Goldfinger
   class Client
     include Goldfinger::Utils
 
-    def initialize(uri, opts = {}, ssl = true)
+    def initialize(uri, opts = {})
       @uri = uri
-      @scheme = ssl ? "https" : "http"
-      @opts = opts || {}
+      @scheme = opts.fetch(:ssl, true) ? "https" : "http"
+      @opts = opts.delete(:ssl) || opts
     end
 
     def finger


### PR DESCRIPTION
## Enable to pass options to HTTP.rb (especially for supporting proxy)

It enable user to customize HTTP.rb client. Especially, it's useful for making requests pass through proxy from/to the restricted network. Like this:
```ruby
proxy = URI.parse('http://gateway.local:8118')
opts = {:proxy => {:proxy_address => proxy.host, :proxy_port => proxy.port}}
Goldfinger.finger('acct:foo@example.com', opts)
```

## Allow insecure request

It enable to request for the non-SSL site, which runs without SSL since long ago, or which is in the network not supposed to use SSL like Tor.
```ruby
Goldfinger.finger('acct:administrator@rainbowdash.net', nil, false)
Goldfinger.finger('acct:admin@social5dgegf5a7k.onion', opts, false)
```