### PR TITLE
#finger should correctly handle %40 in acct uri

### DIFF
--- a/lib/goldfinger/client.rb
+++ b/lib/goldfinger/client.rb
@@ -43,7 +43,7 @@ module Goldfinger
     end
 
     def standard_url
-      "#{@scheme}://#{domain}/.well-known/webfinger?resource=#{@uri}"
+      "#{@scheme}://#{domain}/.well-known/webfinger?resource=#{CGI.escape @uri}"
     end
 
     def url_from_template(template)

--- a/spec/goldfinger/client_spec.rb
+++ b/spec/goldfinger/client_spec.rb
@@ -49,4 +49,17 @@ describe Goldfinger::Client do
       end
     end
   end
+
+  describe '#finger' do
+    before do
+      stub_request(:get, 'https://ab.com/.well-known/webfinger?resource=acct:someone%40gmail.com@ab.com').to_return(status: 404)
+      stub_request(:get, 'https://ab.com/.well-known/webfinger?resource=acct:someone%2540gmail.com@ab.com').to_return(body: fixture('quitter.no_.well-known_webfinger.json'), headers: { content_type: 'application/jrd+json' })
+    end
+
+    subject { Goldfinger::Client.new('acct:someone%40gmail.com@ab.com') }
+
+    it 'should correctly handle %40 in acct uri' do
+      expect(subject.finger).to be_instance_of Goldfinger::Result
+    end
+  end
 end


### PR DESCRIPTION
According to [https://tools.ietf.org/html/rfc7565#section-4](https://tools.ietf.org/html/rfc7565#section-4), `%40` should be allowed in an acct uri. However, the current implementation did not escape `%` in the query string, resulting in an encoding error.